### PR TITLE
Bugfix/heatmap serialization

### DIFF
--- a/Cubusky.Core.Tests/Heatmaps/Json/Serialization/HeatmapJsonConverterTests.cs
+++ b/Cubusky.Core.Tests/Heatmaps/Json/Serialization/HeatmapJsonConverterTests.cs
@@ -77,12 +77,12 @@ namespace Cubusky.Tests.Heatmaps.Json.Serialization
         {
             { new Point2(-3, -3), 7 },
             { new Point2(0, -3), 6 },
-            { new Point2(3, -3), 8 },
+            { new Point2(2, -3), 8 },
 
             { new Point2(-3, 0), 5 },
             { new Point2(3, 0), 2 },
 
-            { new Point2(-3, 3), 9 },
+            { new Point2(-3, 2), 9 },
             { new Point2(0, 3), 3 },
             { new Point2(3, 3), 4 },
         };
@@ -93,7 +93,7 @@ namespace Cubusky.Tests.Heatmaps.Json.Serialization
 #else
             "[0.297100008,0.453700006,0.0190999992,0.806900024,0.448199987,0.1602,0.332899988,0.423799992,0.389899999,0.936500013,0.416399986,0.236499995,0.697799981,0.915199995,0.877099991,0.0860000029]" +
 #endif
-            ",\"Swizzle\":1,\"Bounds\":[-3,-3,7,7],\"Strengths\":[7,-2,6,-2,8,-14,5,-5,2,-14,9,-2,3,-2,4]}";
+            ",\"Swizzle\":1,\"Bounds\":[-3,-3,7,7],\"Strengths\":[7,-2,6,-1,8,-15,5,-5,2,-7,9,-9,3,-2,4]}";
 
         public override void Validate(Heatmap3to2 expected, Heatmap3to2 actual)
         {
@@ -111,7 +111,7 @@ namespace Cubusky.Tests.Heatmaps.Json.Serialization
     {
         public override Heatmap3to2 Result => new Heatmap3to2(new Matrix4x4(0.2971f, 0.4537f, 0.0191f, 0.8069f, 0.4482f, 0.1602f, 0.3329f, 0.4238f, 0.3899f, 0.9365f, 0.4164f, 0.2365f, 0.6978f, 0.9152f, 0.8771f, 0.0860f), Swizzle3to2.YZ)
         {
-            { new Point2(-3, -3), 7 },
+            { new Point2(-1, -3), 7 },
             { new Point2(0, -3), 6 },
             { new Point2(3, -3), 8 },
 
@@ -129,7 +129,7 @@ namespace Cubusky.Tests.Heatmaps.Json.Serialization
 #else
             "[0.297100008,0.453700006,0.0190999992,0.806900024,0.448199987,0.1602,0.332899988,0.423799992,0.389899999,0.936500013,0.416399986,0.236499995,0.697799981,0.915199995,0.877099991,0.0860000029]" +
 #endif
-            ",\"Swizzle\":2,\"Bounds\":[-3,-3,7,7],\"Strengths\":[7,-2,6,-2,8,-14,5,-5,2,-14,9,-2,3,-2,4]}";
+            ",\"Swizzle\":2,\"Bounds\":[-3,-3,7,7],\"Strengths\":[-2,7,6,-2,8,-14,5,-5,2,-14,9,-2,3,-2,4]}";
 
         public override void Validate(Heatmap3to2 expected, Heatmap3to2 actual)
         {
@@ -149,11 +149,11 @@ namespace Cubusky.Tests.Heatmaps.Json.Serialization
         {
             { new Point3(-3, -3, -3), 1 },
             { new Point3(0, -3, -3), 2 },
-            { new Point3(3, -3, -3), 3 },
+            { new Point3(2, -3, -3), 3 },
 
             { new Point3(-3, 0, -3), 4 },
             { new Point3(0, 0, -3), 5 },
-            { new Point3(3, 0, -3), 6 },
+            { new Point3(2, 2, -3), 6 },
 
             { new Point3(-3, 3, -3), 7 },
             { new Point3(0, 3, -3), 8 },
@@ -161,7 +161,7 @@ namespace Cubusky.Tests.Heatmaps.Json.Serialization
 
 
 
-            { new Point3(-3, -3, 0), 10 },
+            { new Point3(-3, -3, -1), 10 },
             { new Point3(0, -3, 0), 11 },
             { new Point3(3, -3, 0), 12 },
 
@@ -171,7 +171,7 @@ namespace Cubusky.Tests.Heatmaps.Json.Serialization
 
             { new Point3(-3, 3, 0), 16 },
             { new Point3(0, 3, 0), 17 },
-            { new Point3(3, 3, 0), 18 },
+            { new Point3(3, 3, 2), 18 },
 
 
 
@@ -194,7 +194,7 @@ namespace Cubusky.Tests.Heatmaps.Json.Serialization
 #else
             "[0.297100008,0.453700006,0.0190999992,0.806900024,0.448199987,0.1602,0.332899988,0.423799992,0.389899999,0.936500013,0.416399986,0.236499995,0.697799981,0.915199995,0.877099991,0.0860000029]" +
 #endif
-            ",\"Bounds\":[-3,-3,-3,7,7,7],\"Strengths\":[1,-2,2,-2,3,-14,4,-2,5,-2,6,-14,7,-2,8,-2,9,-98,10,-2,11,-2,12,-14,13,-2,14,-2,15,-14,16,-2,17,-2,18,-98,19,-2,20,-2,21,-14,22,-2,23,-2,24,-14,25,-2,26,-2,27]}";
+            ",\"Bounds\":[-3,-3,-3,7,7,7],\"Strengths\":[1,-2,2,-1,3,-15,4,-2,5,-15,6,-1,7,-2,8,-2,9,-49,10,-51,11,-2,12,-14,13,-2,14,-2,15,-14,16,-2,17,-100,18,19,-2,20,-2,21,-14,22,-2,23,-2,24,-14,25,-2,26,-2,27]}";
 
         public override void Validate(Heatmap3 expected, Heatmap3 actual)
         {

--- a/Cubusky.Core/Heatmaps/Json/Serialization/Heatmap2JsonConverter.cs
+++ b/Cubusky.Core/Heatmaps/Json/Serialization/Heatmap2JsonConverter.cs
@@ -65,8 +65,8 @@ namespace Cubusky.Heatmaps.Json.Serialization
 
                 if (strength < 0)
                 {
-                    offset.Y += Math.DivRem(-strength, bounds.Width, out var remainder);
-                    offset.X += remainder;
+                    offset.Y += Math.DivRem(-strength + offset.X - bounds.X, bounds.Width, out var remainder);
+                    offset.X = remainder + bounds.X;
 
                     continue;
                 }
@@ -114,14 +114,15 @@ namespace Cubusky.Heatmaps.Json.Serialization
             writer.WriteStartArray();
             foreach (var (cell, strength) in orderedCells)
             {
-                var next = (offset.Y - cell.Y) * bounds.Width + (offset.X - cell.X) + 1;
+                var next = (offset.Y - cell.Y) * bounds.Width + (offset.X - cell.X);
                 if (next < 0)
                 {
                     writer.WriteNumberValue(next);
                 }
-                offset = cell;
-
                 writer.WriteNumberValue(strength);
+
+                offset = cell;
+                offset.X++;
             }
 
             // Write End Array and End Object

--- a/Cubusky.Core/Heatmaps/Json/Serialization/Heatmap3JsonConverter.cs
+++ b/Cubusky.Core/Heatmaps/Json/Serialization/Heatmap3JsonConverter.cs
@@ -65,9 +65,9 @@ namespace Cubusky.Heatmaps.Json.Serialization
 
                 if (strength < 0)
                 {
-                    offset.Z += Math.DivRem(-strength, bounds.Width * bounds.Height, out var remainder);
-                    offset.Y += Math.DivRem(remainder, bounds.Width, out remainder);
-                    offset.X += remainder;
+                    offset.Z += Math.DivRem(-strength + (offset.Y - bounds.Y) * bounds.Width + (offset.X - bounds.X), bounds.Width * bounds.Height, out var remainder);
+                    offset.Y = Math.DivRem(remainder, bounds.Width, out remainder) + bounds.Y;
+                    offset.X = remainder + bounds.X;
 
                     continue;
                 }
@@ -121,15 +121,15 @@ namespace Cubusky.Heatmaps.Json.Serialization
             {
                 var next = (offset.Z - cell.Z) * bounds.Height * bounds.Width
                     + (offset.Y - cell.Y) * bounds.Width
-                    + (offset.X - cell.X)
-                    + 1;
+                    + (offset.X - cell.X);
                 if (next < 0)
                 {
                     writer.WriteNumberValue(next);
                 }
-                offset = cell;
-
                 writer.WriteNumberValue(strength);
+
+                offset = cell;
+                offset.X++;
             }
 
             // Write End Array and End Object

--- a/Cubusky.Core/Heatmaps/Json/Serialization/Heatmap3to2JsonConverter.cs
+++ b/Cubusky.Core/Heatmaps/Json/Serialization/Heatmap3to2JsonConverter.cs
@@ -71,8 +71,8 @@ namespace Cubusky.Heatmaps.Json.Serialization
 
                 if (strength < 0)
                 {
-                    offset.Y += Math.DivRem(-strength, bounds.Width, out var remainder);
-                    offset.X += remainder;
+                    offset.Y += Math.DivRem(-strength + offset.X - bounds.X, bounds.Width, out var remainder);
+                    offset.X = remainder + bounds.X;
 
                     continue;
                 }
@@ -121,14 +121,15 @@ namespace Cubusky.Heatmaps.Json.Serialization
             writer.WriteStartArray();
             foreach (var (cell, strength) in orderedCells)
             {
-                var next = (offset.Y - cell.Y) * bounds.Width + (offset.X - cell.X) + 1;
+                var next = (offset.Y - cell.Y) * bounds.Width + (offset.X - cell.X);
                 if (next < 0)
                 {
                     writer.WriteNumberValue(next);
                 }
-                offset = cell;
-
                 writer.WriteNumberValue(strength);
+
+                offset = cell;
+                offset.X++;
             }
 
             // Write End Array and End Object

--- a/Cubusky.Core/packages.lock.json
+++ b/Cubusky.Core/packages.lock.json
@@ -69,9 +69,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.19, )",
+        "resolved": "8.0.19",
+        "contentHash": "IhHf+zeZiaE5EXRyxILd4qM+Hj9cxV3sa8MpzZgeEhpvaG3a1VEGF6UCaPFLO44Kua3JkLKluE0SWVamS50PlA=="
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Direct",


### PR DESCRIPTION
There were 2 issues to address, 1 with reading and 1 with writing.

Reading: if the offset needed to be moved (due to a negative value in the strengths array), the current position of the offset nor the position of the bounds were taken into account.

Writing: if the very first value was not at the starting position of the heatmap, it would incorrectly move this value one unit to the left and all consecutive units with it. This has been fixed by moving the position after the offset has been copied instead of before.